### PR TITLE
Use millisecond encoding for durations

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -59,7 +59,7 @@ func NewPlanetScaleConfig() zap.Config {
 			LineEnding:     zapcore.DefaultLineEnding,
 			EncodeLevel:    zapcore.LowercaseLevelEncoder,
 			EncodeTime:     zapcore.RFC3339TimeEncoder,
-			EncodeDuration: zapcore.SecondsDurationEncoder,
+			EncodeDuration: zapcore.MillisDurationEncoder,
 			EncodeCaller:   zapcore.ShortCallerEncoder,
 		},
 		OutputPaths:      []string{"stderr"},


### PR DESCRIPTION
The majority of our requests will be subsecond so milliseconds seems slightly more useful to use that for durations as opposed to seconds.