### PR TITLE
Append already written fields from a nested logger

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -114,6 +114,9 @@ func (enc *prettyEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field)
 		zapcore.ShortCallerEncoder(ent.Caller, final)
 	}
 
+	// Write prior fields accumulated from `With()` calls first before writing our new fields.
+	final.buf.Write(enc.buf.Bytes())
+
 	addFields(final, fields)
 
 	if ent.Stack != "" && ent.Level != PanicLevel {

--- a/examples/pretty_logger/main.go
+++ b/examples/pretty_logger/main.go
@@ -40,6 +40,8 @@ func main() {
 
 	time.Sleep(500 * time.Millisecond)
 
+	logger.With(log.String("foo", "bar")).With(log.String("a", "b")).Info("hello", log.Int("int", 1))
+	logger.With(log.Error(errors.New("bye"))).Error("wups 1")
 	logger.Error("wups", log.Error(errors.New("bye")))
 	logger.Fatal("test")
 	logger.Panic("panic")


### PR DESCRIPTION
For a nested logger (created with With()), the fields are written as
soon as With() is called, and are retainined in the buffer.

So we need to explicitly write out those bytes in the correct location.